### PR TITLE
Add a Permission_denied exception

### DIFF
--- a/lib/lwt_vmnet.ml
+++ b/lib/lwt_vmnet.ml
@@ -32,6 +32,8 @@ type error = Vmnet.error =
 
 exception Error of error [@@deriving sexp]
 
+exception Permission_denied
+
 type t = {
   dev: Vmnet.t;
   waiters: unit Lwt.u Lwt_sequence.t sexp_opaque;
@@ -64,6 +66,7 @@ let init ?(mode = Shared_mode) () =
     return t
   ) (function
     | Vmnet.Error err -> fail (Error err)
+    | Vmnet.Permission_denied -> fail Permission_denied
     | e -> fail e)
 
 let rec read t c =

--- a/lib/lwt_vmnet.mli
+++ b/lib/lwt_vmnet.mli
@@ -46,6 +46,10 @@ type error = Vmnet.error =
 (** [Error] can be raised by vmnet functions when hard errors are encountered. *)
 exception Error of error [@@deriving sexp]
 
+(** [Permission_denied] can be raised if the process needs root privileges
+    (or the vmnet capability) *)
+exception Permission_denied
+
 (** [t] is the internal state of one vmnet interface, including Lwt-specific
    waiters and threads. *)
 type t [@@deriving sexp_of]

--- a/lib/vmnet.mli
+++ b/lib/vmnet.mli
@@ -49,6 +49,10 @@ type error =
 (** [Error] can be raised by vmnet functions when hard errors are encountered. *)
 exception Error of error [@@deriving sexp]
 
+(** [Permission_denied] can be raised if the process needs root privileges
+    (or the vmnet capability) *)
+exception Permission_denied
+
 (** [No_packets_waiting] is raised when {!read} is called on an interface that
    has no packets queued.  {!wait_for_event} can be used to block the client
    until packets do arrive. *)


### PR DESCRIPTION
It's quite common to run with insufficient privileges; vmnet.framework is only available if running in sandbox mode with the correct configuration or as root.

This patch catches the error and transforms
```
  Lwt_vmnet.Error(0)
```
into
```
  Lwt_vmnet.Permission_denied
```

Signed-off-by: David Scott <dave@recoil.org>