### PR TITLE
Fix versions and dates in CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,17 +1,17 @@
-1.2.0 (22/5/2017)
+## 1.2.0 (2017-05-22)
 * Fix a possible loss of events
 * Clarify the limits of this (specifically no bridging) in the README
 * Build via jbuilder
 
-1.1.0 (20/3/2016)
+## 1.1.0 (2016-03-20)
 * Replace camlp4 with ppx
 * add LICENSE file
 
-1.0.2 (23/12/2015):
+## 1.0.2 (2015-12-23)
 * Add a test case for Vmnet write.
 
-1.0.1 (02/12/2014):
+## 1.0.1 (2014-12-02)
 * Raise the `Vmnet.Error` exception when interface init fails (#1, reported by @nojb)
 
-1.0.0 (01/12/2014):
+## 1.0.0 (2014-01-12)
 * Initial public release.


### PR DESCRIPTION
This makes the entries `topkg tag`-parseable and switches the dates to YYYY-MM-DD format.

Signed-off-by: David Scott <dave@recoil.org>