### PR TITLE
Make vmnet compile under Lwt 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: c
-sudo: required
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
-env:
-  global:
-    - PACKAGE="vmnet"
+sudo: false
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+script: bash -ex ./.travis-opam.sh
 os:
   - osx
+env:
+  global:
+  - PINS="vmnet:."
+  matrix:
+  - PACKAGE="vmnet"       DISTRO="ubuntu-16.04"    OCAML_VERSION="4.07"
+  - PACKAGE="vmnet"       DISTRO="ubuntu-16.04"    OCAML_VERSION="4.06"
+  - PACKAGE="vmnet"       DISTRO="ubuntu-16.04"    OCAML_VERSION="4.05"
+  - PACKAGE="vmnet"       DISTRO="ubuntu-16.04"    OCAML_VERSION="4.04"

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -12,7 +12,7 @@
 (library
  ((name        vmnet_lwt)
   (public_name vmnet.lwt)
-  (libraries   (vmnet lwt lwt.unix lwt.preemptive))
+  (libraries   (vmnet lwt lwt.unix))
   (modules     (Lwt_vmnet))
   (wrapped     false)
   (preprocess  (pps (ppx_sexp_conv)))

--- a/vmnet.opam
+++ b/vmnet.opam
@@ -1,23 +1,17 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer:   "Anil Madhavapeddy <anil@recoil.org>"
 authors:      "Anil Madhavapeddy <anil@recoil.org>"
 homepage:     "https://github.com/mirage/ocaml-vmnet"
 bug-reports:  "https://github.com/mirage/ocaml-vmnet/issues"
-dev-repo:     "https://github.com/mirage/ocaml-vmnet.git"
+dev-repo:     "git+https://github.com/mirage/ocaml-vmnet.git"
 doc:          "https://mirage.github.io/ocaml-vmnet/"
 license:      "ISC"
 
 build: [
   [ "jbuilder" "subst"] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "jbuilder" "runtest" ] {with-test}
 ]
-
-build-test: [
-  [ "jbuilder" "subst"] {pinned}
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
-  [ "jbuilder" "runtest" ]
-]
-
 depends: [
   "jbuilder"   {build & >="1.0+beta9"}
   "ppx_tools" {build}
@@ -29,7 +23,7 @@ depends: [
   "cstruct" {>="1.9.0"}
   "cstruct-unix"
 ]
-available: [ os = "darwin" ]
+available: [ os = "macos" ]
 post-messages: [
   "This package requires the vmnet.framework plus development headers which are present in Yosemite (10.10.*) and later." {failure}
 ]

--- a/vmnet.opam
+++ b/vmnet.opam
@@ -24,6 +24,7 @@ depends: [
   "cstruct-unix"
 ]
 available: [ os = "macos" ]
+synopsis: "MacOS X `vmnet` NAT networking"
 post-messages: [
   "This package requires the vmnet.framework plus development headers which are present in Yosemite (10.10.*) and later." {failure}
 ]


### PR DESCRIPTION
This doesn't get rid of the warnings for `Lwt_sequence` (see e.g. https://github.com/mirage/mirage-tcpip/issues/349) but makes it compile under Lwt 4.0.x at least.