### PR TITLE
Update to use macaddr 4.0.0

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name        vmnet)
  (public_name vmnet)
- (libraries   bigarray unix cstruct-unix sexplib macaddr macaddr.sexp threads lwt-dllist)
+ (libraries   bigarray unix cstruct-unix sexplib macaddr macaddr-sexp threads lwt-dllist)
  (modules     Vmnet)
  (c_names     vmnet_stubs)
  (c_library_flags (-framework vmnet))

--- a/lib/vmnet.ml
+++ b/lib/vmnet.ml
@@ -93,7 +93,7 @@ let init ?(mode = Shared_mode) () =
     let t = Raw.init mode in
     let name = Printf.sprintf "vmnet%d" !iface_num in
     incr iface_num;
-    let mac = Macaddr.of_bytes_exn t.Raw.mac in
+    let mac = Macaddr.of_octets_exn t.Raw.mac in
     let mtu = t.Raw.mtu in
     let max_packet_size = t.Raw.max_packet_size in
     { iface=t.Raw.iface; mac; mtu; max_packet_size; name }

--- a/vmnet.opam
+++ b/vmnet.opam
@@ -18,7 +18,8 @@ depends: [
   "ppx_sexp_conv"
   "sexplib" {>= "113.24.00"}
   "lwt-dllist"
-  "macaddr"
+  "macaddr" {>="4.0.0"}
+  "macaddr-sexp"
   "lwt" {>="2.4.3"}
   "cstruct" {>="1.9.0"}
   "cstruct-unix"


### PR DESCRIPTION
Minor changes to make it work again with latest release of macaddr (and macaddr-sexp).