### PR TITLE
Fix error handling in read/write and remove Cstruct.set_len

### DIFF
--- a/lib/vmnet.ml
+++ b/lib/vmnet.ml
@@ -112,7 +112,7 @@ let read {iface;_} c =
   let r = Raw.caml_vmnet_read iface c.Cstruct.buffer c.Cstruct.off c.Cstruct.len in
   match r with
   | 0 -> raise No_packets_waiting
-  | len when len > 0 -> Cstruct.set_len c len
+  | len when len > 0 -> Cstruct.sub c 0 len
   | err -> raise (Error (error_of_int (err * (-1))))
 
 let write {iface;_} c =

--- a/lib/vmnet.mli
+++ b/lib/vmnet.mli
@@ -71,7 +71,8 @@ val mtu : t -> int
 
 (** [max_packet_size t] will return the maximum allowed packet buffer that can
     be passed to {!write}.  Exceeding this will raise {!Packet_too_big} from
-    {!write}. *)
+    {!write}. This is also the minimum buffer size that must be passed to
+    {!read}. *)
 val max_packet_size: t -> int
 
 (** [set_event_handler t] will initalise the internal thread state in the library

--- a/lib/vmnet_stubs.c
+++ b/lib/vmnet_stubs.c
@@ -173,7 +173,7 @@ caml_vmnet_read(value v_vmnet, value v_ba, value v_ba_off, value v_ba_len)
   int pktcnt = 1;
   vmnet_return_t res = vmnet_read(iface, &v, &pktcnt);
   if (res != VMNET_SUCCESS)
-    CAMLreturn(Val_int((-1)*res));
+    CAMLreturn(Val_int((-1)*(int32_t)res));
   else if (pktcnt <= 0)
     CAMLreturn(Val_int(0));
   else
@@ -199,5 +199,5 @@ caml_vmnet_write(value v_vmnet, value v_ba, value v_ba_off, value v_ba_len)
   if (res == VMNET_SUCCESS)
     CAMLreturn(Val_int(v.vm_pkt_size));
   else
-    CAMLreturn(Val_int((-1)*res));
+    CAMLreturn(Val_int((-1)*(int32_t)res));
 }


### PR DESCRIPTION
Cast result to int32 before multiplying by -1. Without this the result is not negative and the error is not caught in the Ocaml code.

An error such as the one reported in https://github.com/mirage/mirage-net-macosx/issues/33:
```
2019-03-14 13:16:23 +00:00: ERR [net-macosx] [netif-input] error : (Invalid_argument "Cstruct.set_len [0,1514](1514) 4294966293")
2019-03-14 13:16:23 +00:00: ERR [net-macosx] [netif-input] error : (Invalid_argument "Cstruct.set_len [0,1514](1514) 4294966293")
```
Should now look like this instead:
```
2019-08-22 00:21:48 +02:00: ERR [net-macosx] read: Invalid_argument
2019-08-22 00:21:48 +02:00: ERR [net-macosx] Netif: error, terminating listen loop
```

This PR also removes the deprecated call to `Cstruct.set_len` and documents the `max_packet_size` buffer length requirement (originally causing the `Invalid_argument` above).

(depends on https://github.com/mirage/ocaml-vmnet/pull/28)