### PR TITLE
Support for bridged mode and opening external ports

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name        vmnet)
  (public_name vmnet)
- (libraries   bigarray unix cstruct-unix sexplib macaddr macaddr-sexp threads lwt-dllist)
+ (libraries   bigarray unix cstruct-unix sexplib macaddr macaddr-sexp threads lwt-dllist ipaddr)
  (modules     Vmnet)
  (c_names     vmnet_stubs)
  (c_library_flags (-framework vmnet))

--- a/lib/lwt_vmnet.ml
+++ b/lib/lwt_vmnet.ml
@@ -17,7 +17,7 @@
 open Lwt
 open Sexplib.Conv
 
-type mode = Vmnet.mode = Host_mode | Shared_mode [@@deriving sexp]
+type mode = Vmnet.mode = Host_mode | Shared_mode | Bridged_mode of string [@@deriving sexp]
 
 type error = Vmnet.error =
  | Failure
@@ -90,3 +90,5 @@ let write t c =
     return_unit
   with
   | Vmnet.Error err -> fail (Error err)
+
+let shared_interface_list = Vmnet.shared_interface_list

--- a/lib/lwt_vmnet.ml
+++ b/lib/lwt_vmnet.ml
@@ -92,3 +92,20 @@ let write t c =
   | Vmnet.Error err -> fail (Error err)
 
 let shared_interface_list = Vmnet.shared_interface_list
+
+let add_port_forwarding_rule t protocol ext_port ip int_port =
+  Lwt.catch
+  (fun () ->
+    return (Vmnet.add_port_forwarding_rule t.dev protocol ext_port ip int_port)
+  )(function
+  | Vmnet.Error err -> fail (Error err)
+  | e -> fail e)
+
+let add_tcp_port_forwarding_rule t =
+  add_port_forwarding_rule t 6
+
+let add_udp_port_forwarding_rule t =
+  add_port_forwarding_rule t 17
+
+let add_icmp_port_forwarding_rule t =
+  add_port_forwarding_rule t 1

--- a/lib/lwt_vmnet.mli
+++ b/lib/lwt_vmnet.mli
@@ -82,3 +82,24 @@ val read : t -> Cstruct.t -> Cstruct.t Lwt.t
 val write : t -> Cstruct.t -> unit Lwt.t
 
 val shared_interface_list : unit -> string array
+
+(** [add_port_forwarding_rule t protocol external_port internal_addr
+   internal_port] will create a firewall forwarding rule for the specified
+   protocol, mapping the external_port to the internal_addr/internal_port on
+   the vmnet interface. Protocol is IPPROTO_TCP, IPROTO_UDP etc.*)
+val add_port_forwarding_rule : t -> int -> int -> Ipaddr.V4.t -> int -> unit Lwt.t
+
+(** [add_udp_port_forwarding_rule t external_port internal_addr
+   internal_port] will create a firewall forwarding rule for UDP traffic from
+   external_port to the internal_addr/internal_port on the vmnet interface. *)
+val add_udp_port_forwarding_rule : t -> int -> Ipaddr.V4.t -> int -> unit Lwt.t
+
+(** [add_tcp_port_forwarding_rule t external_port internal_addr
+   internal_port] will create a firewall forwarding rule for TCP traffic from
+   external_port to the internal_addr/internal_port on the vmnet interface. *)
+val add_tcp_port_forwarding_rule : t -> int -> Ipaddr.V4.t -> int -> unit Lwt.t
+
+(** [add_icmp_port_forwarding_rule t external_port internal_addr
+   internal_port] will create a firewall forwarding rule for ICMP traffic from
+   external_port to the internal_addr/internal_port on the vmnet interface. *)
+val add_icmp_port_forwarding_rule : t -> int -> Ipaddr.V4.t -> int -> unit Lwt.t

--- a/lib/lwt_vmnet.mli
+++ b/lib/lwt_vmnet.mli
@@ -29,7 +29,8 @@
     configuration via DHCP). *)
 type mode = Vmnet.mode =
  | Host_mode
- | Shared_mode [@@deriving sexp]
+ | Shared_mode
+ | Bridged_mode of string [@@deriving sexp]
 
 (** [error] represents hard failures from the underlying vmnet functions. *)
 type error = Vmnet.error =
@@ -79,3 +80,5 @@ val read : t -> Cstruct.t -> Cstruct.t Lwt.t
    normally not block, but the vmnet interface isnt clear on whether this might
    happen. *)
 val write : t -> Cstruct.t -> unit Lwt.t
+
+val shared_interface_list : unit -> string array

--- a/lib/vmnet.ml
+++ b/lib/vmnet.ml
@@ -34,6 +34,7 @@ module Raw = struct
   external caml_vmnet_read : interface_ref -> buf -> int -> int -> int = "caml_vmnet_read"
   external caml_vmnet_write : interface_ref -> buf -> int -> int -> int = "caml_vmnet_write"
   external caml_shared_interface_list : unit -> string array = "caml_shared_interface_list"
+  external caml_vmnet_interface_add_port_forwarding_rule : interface_ref -> int -> int -> string -> int -> int = "caml_vmnet_interface_add_port_forwarding_rule"
 
   exception Return_code of int
   exception API_not_supported
@@ -130,4 +131,17 @@ let write {iface;_} c =
 let shared_interface_list =
   Raw.caml_shared_interface_list
 
+let add_port_forwarding_rule {iface;_} protocol ext_port ip int_port =
+  Raw.caml_vmnet_interface_add_port_forwarding_rule iface protocol ext_port (Ipaddr.V4.to_string ip) int_port
+  |> function
+  | 1000 -> () (* VMNET_SUCCESS *)
+  | err -> raise (Error (error_of_int err))
 
+let add_tcp_port_forwarding_rule t =
+  add_port_forwarding_rule t 6
+
+let add_udp_port_forwarding_rule t =
+  add_port_forwarding_rule t 17
+
+let add_icmp_port_forwarding_rule t =
+  add_port_forwarding_rule t 1

--- a/lib/vmnet.ml
+++ b/lib/vmnet.ml
@@ -28,14 +28,17 @@ module Raw = struct
     max_packet_size: int;
   }
 
-  external init : int -> t = "caml_init_vmnet"
+  external init : int -> string -> t = "caml_init_vmnet"
   external set_event_handler : interface_ref -> unit = "caml_set_event_handler"
   external wait_for_event : interface_ref -> unit = "caml_wait_for_event"
   external caml_vmnet_read : interface_ref -> buf -> int -> int -> int = "caml_vmnet_read"
   external caml_vmnet_write : interface_ref -> buf -> int -> int -> int = "caml_vmnet_write"
+  external caml_shared_interface_list : unit -> string array = "caml_shared_interface_list"
 
   exception Return_code of int
+  exception API_not_supported
   let _ = Callback.register_exception "vmnet_raw_return" (Return_code 0)
+  let _ = Callback.register_exception "vmnet_api_not_supported" (API_not_supported)
 end
 
 type error =
@@ -53,6 +56,7 @@ exception Error of error [@@deriving sexp]
 exception Permission_denied
 exception No_packets_waiting [@@deriving sexp]
 
+(* Possible values of vmnet_return_t *)
 let error_of_int =
   function
   | 1001 -> Failure
@@ -67,7 +71,8 @@ let error_of_int =
 
 type mode =
   | Host_mode
-  | Shared_mode [@@deriving sexp]
+  | Shared_mode
+  | Bridged_mode of string [@@deriving sexp]
 
 type t = {
   iface: interface_ref sexp_opaque;
@@ -84,23 +89,24 @@ let max_packet_size {max_packet_size; _} = max_packet_size
 let iface_num = ref 0
 
 let init ?(mode = Shared_mode) () =
-  let mode =
+  let mode, iface =
     match mode with
-    | Host_mode -> 1000
-    | Shared_mode -> 1001
+    | Host_mode -> (1000, "")
+    | Shared_mode -> (1001, "")
+    | Bridged_mode iface -> (1002, iface)
   in
   try
-    let t = Raw.init mode in
+    let t = Raw.init mode iface in
     let name = Printf.sprintf "vmnet%d" !iface_num in
     incr iface_num;
     let mac = Macaddr.of_octets_exn t.Raw.mac in
     let mtu = t.Raw.mtu in
     let max_packet_size = t.Raw.max_packet_size in
     { iface=t.Raw.iface; mac; mtu; max_packet_size; name }
-  with Raw.Return_code r ->
-    if r = 1001 && Unix.geteuid() <> 0
-    then raise Permission_denied
-    else raise (Error (error_of_int r))
+  with 
+    | Raw.Return_code r -> if r = 1001 && Unix.geteuid() <> 0
+			   then raise Permission_denied
+			   else raise (Error (error_of_int r))
 
 let set_event_handler {iface; _} =
   Raw.set_event_handler iface
@@ -120,3 +126,8 @@ let write {iface;_} c =
   |> function
   | len when len > 0 -> ()
   | err -> raise (Error (error_of_int (err * (-1))))
+
+let shared_interface_list =
+  Raw.caml_shared_interface_list
+
+

--- a/lib/vmnet.mli
+++ b/lib/vmnet.mli
@@ -96,3 +96,24 @@ val read : t -> Cstruct.t -> Cstruct.t
 val write : t -> Cstruct.t -> unit
 
 val shared_interface_list : unit -> string array
+
+(** [add_port_forwarding_rule t protocol external_port internal_addr
+   internal_port] will create a firewall forwarding rule for the specified
+   protocol, mapping the external_port to the internal_addr/internal_port on
+   the vmnet interface. Protocol is IPPROTO_TCP, IPROTO_UDP etc.*)
+val add_port_forwarding_rule : t -> int -> int -> Ipaddr.V4.t -> int -> unit
+
+(** [add_udp_port_forwarding_rule t external_port internal_addr
+   internal_port] will create a firewall forwarding rule for UDP traffic from
+   external_port to the internal_addr/internal_port on the vmnet interface. *)
+val add_udp_port_forwarding_rule : t -> int -> Ipaddr.V4.t -> int -> unit
+
+(** [add_tcp_port_forwarding_rule t external_port internal_addr
+   internal_port] will create a firewall forwarding rule for TCP traffic from
+   external_port to the internal_addr/internal_port on the vmnet interface. *)
+val add_tcp_port_forwarding_rule : t -> int -> Ipaddr.V4.t -> int -> unit
+
+(** [add_icmp_port_forwarding_rule t external_port internal_addr
+   internal_port] will create a firewall forwarding rule for ICMP traffic from
+   external_port to the internal_addr/internal_port on the vmnet interface. *)
+val add_icmp_port_forwarding_rule : t -> int -> Ipaddr.V4.t -> int -> unit

--- a/lib/vmnet.mli
+++ b/lib/vmnet.mli
@@ -32,7 +32,8 @@ type t [@@deriving sexp_of]
     configuration via DHCP). *)
 type mode =
   | Host_mode
-  | Shared_mode [@@deriving sexp]
+  | Shared_mode
+  | Bridged_mode of string [@@deriving sexp]
 
 (** [error] represents hard failures from the underlying vmnet functions. *)
 type error =
@@ -93,3 +94,5 @@ val read : t -> Cstruct.t -> Cstruct.t
    normally not block, but the vmnet interface isnt clear on whether this might
    happen. *)
 val write : t -> Cstruct.t -> unit
+
+val shared_interface_list : unit -> string array

--- a/lib/vmnet_stubs.c
+++ b/lib/vmnet_stubs.c
@@ -90,7 +90,7 @@ caml_init_vmnet(value v_mode, value v_iface)
   xpc_object_t interface_desc = xpc_dictionary_create(NULL, NULL, 0);
   xpc_dictionary_set_uint64(interface_desc, vmnet_operation_mode_key, Int_val(v_mode));
 
-  #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
+  #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
   if (Int_val(v_mode) == VMNET_BRIDGED_MODE) {
 	// If bridged mode is set we have to supply the interface as a string
 	xpc_dictionary_set_string(interface_desc, vmnet_shared_interface_name_key, String_val(v_iface));
@@ -146,8 +146,9 @@ caml_init_vmnet(value v_mode, value v_iface)
 
 CAMLprim value
 caml_shared_interface_list (void) {
-  #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
   CAMLparam0();
+
+  #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
   CAMLlocal1(ret_array);
 
   xpc_object_t l = vmnet_copy_shared_interface_list();
@@ -169,6 +170,7 @@ caml_shared_interface_list (void) {
 
   #else
   caml_raise_api_not_supported();
+  CAMLreturn(Atom(0)); // Not reached
   #endif
 }
 
@@ -257,7 +259,7 @@ caml_vmnet_interface_add_port_forwarding_rule(value v_vmnet, value v_protocol,
 		value v_ext_port, value v_int_addr, value v_int_port) {
   CAMLparam5(v_vmnet, v_protocol, v_ext_port, v_int_addr, v_int_port);
 
-  #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
+  #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
   struct vmnet_state *vms = Vmnet_state_val(v_vmnet);
 
   interface_ref iface = vms->iref;
@@ -289,5 +291,6 @@ caml_vmnet_interface_add_port_forwarding_rule(value v_vmnet, value v_protocol,
 
   #else
   caml_raise_api_not_supported();
+  CAMLreturn(Val_int(1000)); // Not reached
   #endif
 }

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,3 +1,3 @@
 (executables
- (names vmnet_listen vmnet_write)
- (libraries vmnet))
+ (names vmnet_listen vmnet_write vmnet_list_shared vmnet_fw_test)
+ (libraries vmnet charrua-client arp ethernet))

--- a/lib_test/vmnet_fw_test.ml
+++ b/lib_test/vmnet_fw_test.ml
@@ -1,0 +1,133 @@
+(*
+ * Copyright (c) 2019 Magnus Skjegstad <magnus@skjegstad.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(* Vmnet unix example with port forwarding from an external interface. As we
+ * don't have an OS to help us, we use Mirage libraries to construct a DHCP
+ * request and send gARP to announce our IP to the bridge. The local IP is then
+ * used to set up the firewall rule to forward a port from the external 
+ * interface (typically en0).
+ *
+ * Note: In 10.15 it seems that the port will only be open if accessed from the
+ * network. Connecting to the external IP from the same machine will not work.
+ *)
+
+let rec blocking_read t buf = 
+        Vmnet.wait_for_event t;
+        try
+                Vmnet.read t buf
+        with
+        | Vmnet.No_packets_waiting -> blocking_read t buf
+        | e -> raise e
+
+let rec wait_for_lease vmnet_t state =
+        let pkt_buf = (Cstruct.create (Vmnet.max_packet_size vmnet_t)) in
+        match state with
+        | None -> begin
+              let random_xid = (Random.int32 Int32.max_int) in
+              let mac = Vmnet.mac vmnet_t in
+              print_endline (Printf.sprintf "Requesting DHCP lease for vmnet interface with mac %s" (Macaddr.to_string mac));
+              let (dhcp_t, pkt) = Dhcp_client.create random_xid mac in
+              Vmnet.write vmnet_t (Dhcp_wire.buf_of_pkt pkt);
+              wait_for_lease vmnet_t (Some dhcp_t)
+        end
+        | Some dhcp_t -> begin
+              let buf = blocking_read vmnet_t pkt_buf in
+              match (Dhcp_client.input dhcp_t buf) with
+              | `Noop -> begin
+                      wait_for_lease vmnet_t (Some dhcp_t)
+              end
+              | `Response (dhcp_t', pkt) -> begin
+                      Vmnet.write vmnet_t (Dhcp_wire.buf_of_pkt pkt);
+                      wait_for_lease vmnet_t (Some dhcp_t')
+              end
+              | `New_lease (_, pkt') -> begin
+                      pkt'.yiaddr
+              end
+        end
+
+let send_garp vmnet_t mac ip =
+  let garp = Arp_packet.({
+          operation = Request;
+          source_mac = mac;
+          target_mac = (Macaddr.of_octets_exn (Cstruct.to_string (Cstruct.create 6))); (* all 0s *)
+          source_ip = ip;
+          target_ip = ip;
+  })
+  in
+  let ether = Ethernet_packet.({
+          source = mac;
+          destination = Macaddr.broadcast;
+          ethertype = `ARP
+  }) in
+  let arp_pkt = (Cstruct.create (Arp_packet.size + Ethernet_wire.sizeof_ethernet)) in
+  let _ = Ethernet_packet.Marshal.into_cstruct ether arp_pkt in
+  Arp_packet.encode_into garp (Cstruct.sub arp_pkt Ethernet_wire.sizeof_ethernet Arp_packet.size);
+  Vmnet.write vmnet_t arp_pkt
+
+let _ =
+  Random.self_init ();
+
+  (* init vmnet interface *)
+  print_endline "Calling Vmnet.init ()";
+  let vmnet_t = Vmnet.init ~mode:Shared_mode () in
+  let () = Vmnet.set_event_handler vmnet_t in
+
+  (* get DHCP lease *)
+  let local_ip = (wait_for_lease vmnet_t None) in
+  print_endline (Printf.sprintf "Got DHCP lease %s" (Ipaddr.V4.to_string local_ip));
+
+  (* send gARP so gateway finds us when routing external traffic *)
+  let mac = Vmnet.mac vmnet_t in
+  print_endline (Printf.sprintf "Sending gARP for %s" (Macaddr.to_string mac));
+  send_garp vmnet_t mac local_ip;
+
+  (* set up port forwarding *)
+  print_endline "Creating a TCP forwarding rule for port 1234";
+  Vmnet.add_tcp_port_forwarding_rule vmnet_t 1234 local_ip 1234;
+
+  print_endline "Traffic sent to the external IP on TCP port 1234 should now appear here.";
+
+  (* output incoming packet headers *)
+  let rec listen_and_print () =
+          let buf = blocking_read vmnet_t (Cstruct.create (Vmnet.max_packet_size vmnet_t)) in
+          (match Ethernet_wire.(int_to_ethertype (get_ethernet_ethertype buf)) with
+          | Some `IPv4 -> begin
+                (* manually extract ip src/dst *)
+                let src_ip = Ipaddr.V4.of_int32 (Cstruct.BE.get_uint32 buf (Ethernet_wire.sizeof_ethernet + 12)) in
+                let dst_ip = Ipaddr.V4.of_int32 (Cstruct.BE.get_uint32 buf (Ethernet_wire.sizeof_ethernet + 16)) in
+                let proto = Cstruct.get_uint8 buf (Ethernet_wire.sizeof_ethernet + 9) in
+                (match (Ipaddr.V4.compare dst_ip local_ip), proto with
+                | 0, 6 -> begin (* dst=local_ip, proto=tcp *)
+                                print_endline (Printf.sprintf "src %s, dst %s, proto %d" (Ipaddr.V4.to_string src_ip) (Ipaddr.V4.to_string dst_ip) proto)
+                        end 
+                | _ -> ())
+          end
+          | Some `ARP -> begin 
+                  (* reply to ARP requests if the initial gARP times out. This is a bit hacky as we send gARP in reply to requests *)
+                  let arp_buf = Cstruct.sub buf Ethernet_wire.sizeof_ethernet ((Cstruct.len buf) - Ethernet_wire.sizeof_ethernet) in
+                  (match (Arp_packet.decode arp_buf) with
+                  | Error _ -> ()
+                  | Ok arp_t -> begin
+                          match (Ipaddr.V4.compare arp_t.target_ip local_ip) with
+                          | 0 -> send_garp vmnet_t mac local_ip
+                          | _ -> ()
+                  end)
+          end
+          | _ -> ());
+          listen_and_print ()
+  in
+  listen_and_print ()
+

--- a/lib_test/vmnet_list_shared.ml
+++ b/lib_test/vmnet_list_shared.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2019 Magnus Skjegstad <magnus@skjegstad.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -15,19 +15,8 @@
  *)
 
 let _ =
-  print_endline "init";
-  let t = Vmnet.init () in
-  let buf_size = Vmnet.max_packet_size t in
-  Printf.printf "mtu %d\n%!" (Vmnet.mtu t);
-  Printf.printf "max packet size %d\n%!" buf_size;
-  let dump () =
-    Vmnet.read t (Cstruct.create buf_size)
-    |> Cstruct.hexdump;
-  in
-  Vmnet.set_event_handler t;
-  dump ();
-  print_endline "read";
-  Unix.sleep 2;
-  Vmnet.write t (Cstruct.create buf_size);
-  Unix.sleep 10;
-  print_endline "end init"
+  let rec print_if = (function
+    [] -> ()
+    | e::l -> (Printf.printf "%s\n" e); print_if l) in
+  Printf.printf "Interfaces found with BRIDGED_MODE support (wired only):\n";
+  print_if (Array.to_list (Vmnet.shared_interface_list ()))

--- a/lib_test/vmnet_listen.ml
+++ b/lib_test/vmnet_listen.ml
@@ -17,9 +17,11 @@
 let _ =
   print_endline "init";
   let t = Vmnet.init () in
+  let buf_size = Vmnet.max_packet_size t in
   Printf.printf "mtu %d\n%!" (Vmnet.mtu t);
+  Printf.printf "max packet size %d\n%!" buf_size;
   let dump () =
-    Vmnet.read t (Cstruct.create 4096)
+    Vmnet.read t (Cstruct.create buf_size)
     |> Cstruct.hexdump;
   in
   Vmnet.set_event_handler t;

--- a/lib_test/vmnet_write.ml
+++ b/lib_test/vmnet_write.ml
@@ -20,7 +20,5 @@ let _ =
     Printf.printf "write: %d\n%!" sz;
     Vmnet.write t (Cstruct.create sz) in
   Vmnet.set_event_handler t;
-  dump 4096;
-  dump 128;
-  dump 12;
+  dump (Vmnet.max_packet_size t);
   Unix.sleep 1

--- a/vmnet.opam
+++ b/vmnet.opam
@@ -17,6 +17,7 @@ depends: [
   "dune"
   "ppx_sexp_conv"
   "sexplib" {>= "113.24.00"}
+  "ipaddr"
   "lwt-dllist"
   "macaddr" {>="4.0.0"}
   "macaddr-sexp"

--- a/vmnet.opam
+++ b/vmnet.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer:   "Anil Madhavapeddy <anil@recoil.org>"
-authors:      "Anil Madhavapeddy <anil@recoil.org>"
+authors:      ["Anil Madhavapeddy" "Magnus Skjegstad"]
 homepage:     "https://github.com/mirage/ocaml-vmnet"
 bug-reports:  "https://github.com/mirage/ocaml-vmnet/issues"
 dev-repo:     "git+https://github.com/mirage/ocaml-vmnet.git"
@@ -21,6 +21,9 @@ depends: [
   "lwt-dllist"
   "macaddr" {>="4.0.0"}
   "macaddr-sexp"
+  "charrua-client" {with-test}
+  "arp" {with-test}
+  "ethernet" {with-test}
   "lwt" {>="2.4.3"}
   "cstruct" {>="1.9.0"}
   "cstruct-unix"
@@ -38,6 +41,8 @@ There are a number of advantages of this over previous implementations:
   drop a hard dependency on running networking applications as `root`.
 - Most significantly, `vmnet` optionally supports NATing network traffic to the
   outside world, which was previously unsupported.
+- As of 10.15 (Catalina), Vmnet also supports listening on external ports,
+  bridging physical (wired) interfaces and IPv6 (via NAT66).
 
 These OCaml bindings are constructed against the documentation contained
 in the `<vmnet.h>` header file in Yosemite, and may not be correct due to


### PR DESCRIPTION
macOS 10.15 (Catalina) adds several new features to `vmnet.framework`. This includes a new bridged mode and support for forwarding external ports to the internal interface (in shared mode). IPv6 also seems to be supported (with NAT66), but I haven't verified this.

This PR adds support for bridged mode and adding firewall rules. It also adds two new examples/tests for listing the interfaces that can be bridged (typically wired interfaces) and for adding a firewall rule.

The firewall example is a bit complicated, as it needs to use DHCP and ARP to get the IP address, but I included it as it was useful for testing the API calls. I'm not sure how this functionality should be integrated with `mirage-net-macosx` yet though. Perhaps it would be possible to include the firewall features in an external tool that can be used to manage the interface (if the framework allows it).

Updated Vmnet documentation is available here: https://developer.apple.com/documentation/vmnet. There's also additional information in the header file that comes with the updated SDK.
