### PR TITLE
Add more bindings for 10.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _opam
 .*.swp
 _build
+.vscode

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## unreleased
+
+* Add support for macOS 10.15 bridge mode (#32 @magnuss)
+* Add support for macOS 10.15 firewall rules (#32 @magnuss)
+* Add support for macOS 10.15 custom IPv4 configuration (#33 @magnuss)
+* Add support for reusing the same UUID between interfaces (#33 @magnuss)
+* Add examples for setting up firewall rules, custom IPv4 config and listing
+  shared interfaces (#32 #33 @magnuss)
+* Remove {build} from dune in opam-file (#31 @magnuss)
+
 ## v1.5.1 (2019-09-14)
 * Report errors correctly from read/write (#29 @magnuss)
 * Remove deprecated calls to `Cstruct.set_len` (#29 @magnuss)

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name        vmnet)
  (public_name vmnet)
- (libraries   bigarray unix cstruct-unix sexplib macaddr macaddr-sexp threads lwt-dllist ipaddr)
+ (libraries   bigarray unix cstruct-unix sexplib macaddr macaddr-sexp threads lwt-dllist ipaddr uuidm)
  (modules     Vmnet)
  (c_names     vmnet_stubs)
  (c_library_flags (-framework vmnet))

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name        vmnet)
  (public_name vmnet)
- (libraries   bigarray unix cstruct-unix sexplib macaddr macaddr-sexp threads lwt-dllist ipaddr uuidm)
+ (libraries   bigarray unix cstruct-unix sexplib macaddr macaddr-sexp threads lwt-dllist ipaddr ipaddr-sexp uuidm)
  (modules     Vmnet)
  (c_names     vmnet_stubs)
  (c_library_flags (-framework vmnet))

--- a/lib/lwt_vmnet.ml
+++ b/lib/lwt_vmnet.ml
@@ -22,6 +22,12 @@ type mode = Vmnet.mode = Host_mode | Shared_mode | Bridged_mode of string [@@der
 
 type proto = Vmnet.proto = TCP | UDP | ICMP | Other of int [@@deriving sexp]
 
+type ipv4_config = Vmnet.ipv4_config = {
+    ipv4_start_address: Ipaddr_sexp.V4.t;
+    ipv4_end_address: Ipaddr_sexp.V4.t;
+    ipv4_netmask: Ipaddr_sexp.V4.t;
+} [@@deriving sexp]
+
 type error = Vmnet.error =
  | Failure
  | Mem_failure
@@ -60,10 +66,10 @@ let wait_for_event t =
     loop ()
   in loop ()
 
-let init ?(mode = Shared_mode) () =
+let init ?(mode = Shared_mode) ?(uuid = Uuidm.nil) ?ipv4_config () =
   Lwt.catch
   (fun () ->
-    let dev = Vmnet.init ~mode () in
+    let dev = Vmnet.init ~mode ~uuid ?ipv4_config () in
     let waiters = Lwt_dllist.create () in
     let t = { dev; waiters } in
     let _ = wait_for_event t in

--- a/lib/vmnet.mli
+++ b/lib/vmnet.mli
@@ -1,5 +1,6 @@
 (*
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2019 Magnus Skjegstad <magnus@skjegstad.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -34,6 +35,14 @@ type mode =
   | Host_mode
   | Shared_mode
   | Bridged_mode of string [@@deriving sexp]
+
+(** [proto] specifies protocol used in firewall rules. {!Other} can be
+    used to add rules for undefined protocol types. *)
+type proto =
+  | TCP
+  | UDP
+  | ICMP
+  | Other of int [@@deriving sexp]
 
 (** [error] represents hard failures from the underlying vmnet functions. *)
 type error =
@@ -95,25 +104,21 @@ val read : t -> Cstruct.t -> Cstruct.t
    happen. *)
 val write : t -> Cstruct.t -> unit
 
+(** [shared_interface_list] will return an array of interface names that support
+   bridged mode. *)
 val shared_interface_list : unit -> string array
+
+(** [get_forwarding_rules t] returns an array of existing firewall rules. Each
+   rule contains the protocol number, internal port, internal IP address and
+   external port. *)
+val get_port_forwarding_rules : t -> (proto * int * Ipaddr.V4.t * int) array
 
 (** [add_port_forwarding_rule t protocol external_port internal_addr
    internal_port] will create a firewall forwarding rule for the specified
    protocol, mapping the external_port to the internal_addr/internal_port on
-   the vmnet interface. Protocol is IPPROTO_TCP, IPROTO_UDP etc.*)
-val add_port_forwarding_rule : t -> int -> int -> Ipaddr.V4.t -> int -> unit
+   the vmnet interface. *)
+val add_port_forwarding_rule : t -> proto -> int -> Ipaddr.V4.t -> int -> unit
 
-(** [add_udp_port_forwarding_rule t external_port internal_addr
-   internal_port] will create a firewall forwarding rule for UDP traffic from
-   external_port to the internal_addr/internal_port on the vmnet interface. *)
-val add_udp_port_forwarding_rule : t -> int -> Ipaddr.V4.t -> int -> unit
-
-(** [add_tcp_port_forwarding_rule t external_port internal_addr
-   internal_port] will create a firewall forwarding rule for TCP traffic from
-   external_port to the internal_addr/internal_port on the vmnet interface. *)
-val add_tcp_port_forwarding_rule : t -> int -> Ipaddr.V4.t -> int -> unit
-
-(** [add_icmp_port_forwarding_rule t external_port internal_addr
-   internal_port] will create a firewall forwarding rule for ICMP traffic from
-   external_port to the internal_addr/internal_port on the vmnet interface. *)
-val add_icmp_port_forwarding_rule : t -> int -> Ipaddr.V4.t -> int -> unit
+(** [remove_port_forwarding_rule t protocol external_port] removes an existing
+   firewall rule. *)
+val remove_port_forwarding_rule : t -> proto -> int -> unit

--- a/lib/vmnet.mli
+++ b/lib/vmnet.mli
@@ -68,9 +68,11 @@ exception Permission_denied
    until packets do arrive. *)
 exception No_packets_waiting [@@deriving sexp]
 
-(** [init ?mode] will initialise a fresh vmnet interface, defaulting to
-    {!Shared_mode} for the output. Raises {!Error} if something goes wrong. *)
-val init : ?mode:mode -> unit -> t
+(** [init ?mode ?uuid] will initialise a vmnet interface, defaulting to
+    {!Shared_mode} for the output. UUID is randomly generated if not specified. 
+    Subsequent calls to [init] with the same UUID will provide an interface with
+    the same configuration. Raises {!Error} if something goes wrong. *)
+val init : ?mode:mode -> ?uuid:Uuidm.t-> unit -> t
 
 (** [mac t] will return the MAC address bound to the guest network interface. *)
 val mac : t -> Macaddr.t
@@ -78,6 +80,9 @@ val mac : t -> Macaddr.t
 (** [mtu t] will return the Maximum Transmission Unit (MTU) bound to the
     guest network interface. *)
 val mtu : t -> int
+
+(** [uuid t] will return the UUID identifying this Vmnet interface. *)
+val uuid : t -> Uuidm.t
 
 (** [max_packet_size t] will return the maximum allowed packet buffer that can
     be passed to {!write}.  Exceeding this will raise {!Packet_too_big} from

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,3 +1,3 @@
 (executables
  (names vmnet_listen vmnet_write vmnet_list_shared vmnet_fw_test)
- (libraries vmnet charrua-client arp ethernet))
+ (libraries vmnet charrua-client arp ethernet uuidm))

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,3 +1,3 @@
 (executables
  (names vmnet_listen vmnet_write vmnet_list_shared vmnet_fw_test)
- (libraries vmnet charrua-client arp ethernet uuidm))
+ (libraries vmnet charrua-client arp ethernet uuidm ipaddr))

--- a/lib_test/vmnet_fw_test.ml
+++ b/lib_test/vmnet_fw_test.ml
@@ -77,13 +77,34 @@ let send_garp vmnet_t mac ip =
   Arp_packet.encode_into garp (Cstruct.sub arp_pkt Ethernet_wire.sizeof_ethernet Arp_packet.size);
   Vmnet.write vmnet_t arp_pkt
 
+let print_fw_rules vmnet_t =
+  print_endline "proto\text\tinternal ip\tint";
+  let rules = Vmnet.get_port_forwarding_rules vmnet_t in
+  Array.iter (fun (proto, ext_port, ip, int_port) ->
+        let proto_s =
+                Vmnet.(match proto with
+                | TCP -> "tcp"
+                | UDP -> "udp"
+                | ICMP -> "icmp"
+                | Other _ -> "other")
+        in
+        Printf.printf "%s\t%d\t%s\t%d\n" proto_s ext_port (Ipaddr.V4.to_string ip) int_port)
+        rules
+
 let _ =
   Random.self_init ();
 
   (* init vmnet interface *)
   print_endline "Calling Vmnet.init ()";
-  let vmnet_t = Vmnet.init ~mode:Shared_mode () in
+  let ipv4_config = Vmnet.({
+                 ipv4_start_address = (Ipaddr.V4.of_string_exn "192.168.123.1");
+                 ipv4_end_address = (Ipaddr.V4.of_string_exn "192.168.123.128");
+                 ipv4_netmask = (Ipaddr.V4.of_string_exn "255.255.255.0")
+        }) in
+  let vmnet_t = Vmnet.init ~mode:(Shared_mode) ~ipv4_config () in
   Printf.printf "Vmnet interface UUID is %s\n" (Uuidm.to_string (Vmnet.uuid vmnet_t));
+  print_endline (Printf.sprintf "MAC is %s" (Macaddr.to_string (Vmnet.mac vmnet_t)));
+
   let () = Vmnet.set_event_handler vmnet_t in
 
   (* get DHCP lease *)
@@ -106,17 +127,7 @@ let _ =
   Vmnet.remove_port_forwarding_rule vmnet_t UDP 1234;
 
   print_endline "Active firewall rules:";
-  print_endline "proto\text\tinternal ip\tint";
-  Array.iter (fun (proto, ext_port, ip, int_port) ->
-        let proto_s =
-                Vmnet.(match proto with
-                | TCP -> "tcp"
-                | UDP -> "udp"
-                | ICMP -> "icmp"
-                | Other _ -> "other")
-        in
-        Printf.printf "%s\t%d\t%s\t%d\n" proto_s ext_port (Ipaddr.V4.to_string ip) int_port)
-        (Vmnet.get_port_forwarding_rules vmnet_t);
+  print_fw_rules vmnet_t;
 
   print_endline "Traffic sent to the external IP on TCP port 1234 should now appear here.";
 

--- a/lib_test/vmnet_fw_test.ml
+++ b/lib_test/vmnet_fw_test.ml
@@ -95,8 +95,27 @@ let _ =
   send_garp vmnet_t mac local_ip;
 
   (* set up port forwarding *)
-  print_endline "Creating a TCP forwarding rule for port 1234";
-  Vmnet.add_tcp_port_forwarding_rule vmnet_t 1234 local_ip 1234;
+  print_endline "Creating some forwarding rules...";
+  Vmnet.add_port_forwarding_rule vmnet_t TCP 1234 local_ip 1234;
+  Vmnet.add_port_forwarding_rule vmnet_t TCP 1235 local_ip 1235;
+  Vmnet.add_port_forwarding_rule vmnet_t TCP 1236 local_ip 1236;
+  Vmnet.add_port_forwarding_rule vmnet_t UDP 1234 local_ip 1234;
+
+  print_endline "Removing one rule";
+  Vmnet.remove_port_forwarding_rule vmnet_t UDP 1234;
+
+  print_endline "Active firewall rules:";
+  print_endline "proto\text\tinternal ip\tint";
+  Array.iter (fun (proto, ext_port, ip, int_port) ->
+        let proto_s =
+                Vmnet.(match proto with
+                | TCP -> "tcp"
+                | UDP -> "udp"
+                | ICMP -> "icmp"
+                | Other _ -> "other")
+        in
+        Printf.printf "%s\t%d\t%s\t%d\n" proto_s ext_port (Ipaddr.V4.to_string ip) int_port)
+        (Vmnet.get_port_forwarding_rules vmnet_t);
 
   print_endline "Traffic sent to the external IP on TCP port 1234 should now appear here.";
 
@@ -130,4 +149,3 @@ let _ =
           listen_and_print ()
   in
   listen_and_print ()
-

--- a/lib_test/vmnet_fw_test.ml
+++ b/lib_test/vmnet_fw_test.ml
@@ -83,6 +83,7 @@ let _ =
   (* init vmnet interface *)
   print_endline "Calling Vmnet.init ()";
   let vmnet_t = Vmnet.init ~mode:Shared_mode () in
+  Printf.printf "Vmnet interface UUID is %s\n" (Uuidm.to_string (Vmnet.uuid vmnet_t));
   let () = Vmnet.set_event_handler vmnet_t in
 
   (* get DHCP lease *)

--- a/vmnet.opam
+++ b/vmnet.opam
@@ -18,6 +18,7 @@ depends: [
   "ppx_sexp_conv"
   "sexplib" {>= "113.24.00"}
   "ipaddr"
+  "ipaddr-sexp"
   "lwt-dllist"
   "macaddr" {>="4.0.0"}
   "macaddr-sexp"

--- a/vmnet.opam
+++ b/vmnet.opam
@@ -27,6 +27,7 @@ depends: [
   "lwt" {>="2.4.3"}
   "cstruct" {>="1.9.0"}
   "cstruct-unix"
+  "uuidm"
 ]
 available: [ os = "macos" ]
 synopsis: "MacOS X `vmnet` NAT networking"


### PR DESCRIPTION
This adds remaining macOS 10.15 bindings for:

- Removing and listing firewall rules. I've also changed the interface a bit and added a protocol type to avoid having a separate call for each of the most common protocols.
- Specifying an optional UUID to the init function. This is useful if you want to retain the IP between invocations, as Vmnet will generate an interface with the same MAC address as long as the UUID is the same.
- Specifying an optional IPv4 config. This allows the user to set the IP range, with the start address becoming the gateway. If the end address is lower than what the subnet mask allows, the remaining IPs can be used for static allocation.

When this is merged we should only miss IPv6 support, which I'm unable to test at the moment. It should be relatively straight forward to implement this by passing another configuration to `init` (similar to `ipv4_config`) and set the [right keys](https://developer.apple.com/documentation/vmnet/vmnet_constants) in the dictionary.

This PR is relatively large, but is separated in commits per new feature to make it easier to review.

Output of `vmnet_fw_test` with custom IP range (external TCP SYNs sent from 10.1.1.2):
```
 % sudo dune exec lib_test/vmnet_fw_test.exe
Calling Vmnet.init ()
Vmnet interface UUID is 0386d925-8827-43cb-b78b-acae12c4a871
MAC is 0e:1e:06:19:ca:d5
Requesting DHCP lease for vmnet interface with mac 0e:1e:06:19:ca:d5
Got DHCP lease 192.168.123.9
Sending gARP for 0e:1e:06:19:ca:d5
Creating some forwarding rules...
Removing one rule
Active firewall rules:
proto	ext	internal ip	int
tcp	1234	192.168.123.9	1234
tcp	1235	192.168.123.9	1235
tcp	1236	192.168.123.9	1236
Traffic sent to the external IP on TCP port 1234 should now appear here.
src 10.1.1.2, dst 192.168.123.9, proto 6
src 10.1.1.2, dst 192.168.123.9, proto 6
src 10.1.1.2, dst 192.168.123.9, proto 6
```

I'm still not sure how to expose these new features in `mirage-net-macosx`, but from experiments it seems that if you have an interface on the same subnet you're able to add firewall rules for other IPs in the same subnet. This may allow an external tool to open ports to the unikernel after it has been started.